### PR TITLE
Support downloading tarballs

### DIFF
--- a/bin/download-crds.py
+++ b/bin/download-crds.py
@@ -1,7 +1,9 @@
 from typing import List
 from yaml import safe_load, YAMLError
 import requests
+import tarfile
 import sys
+from io import BytesIO
 
 with open("./sdks.yaml", "r") as stream:
     try:
@@ -15,6 +17,17 @@ crd_urls: List[str] = details["crds"]
 
 with open("crd.yaml", 'wb') as f:
     for crd_url in crd_urls:
-        crd = requests.get(crd_url.replace('${VERSION}', version)).content
-        f.write(crd)
-        f.write(b"---\n")
+        crd_url = crd_url.replace('${VERSION}', version)
+        if crd_url.endswith('.tar.gz'):
+            response = requests.get(crd_url, stream=True)
+            with tarfile.open(fileobj=response.raw, mode="r|gz") as tf:
+                for (info, crdfile) in ((m, tf.extractfile(m)) for m in tf):
+                    if crdfile is not None:
+                        f.write(("# url: %s file: %s\n" % (crd_url, info.name)).encode('utf-8'))
+                        f.write(crdfile.read())
+                        f.write(b"\n---\n")
+        else:
+            crd = requests.get(crd_url).content
+            f.write(("# url: %s\n" % crd_url).encode('utf-8'))
+            f.write(crd)
+            f.write(b"---\n")


### PR DESCRIPTION
This makes a small adjustment so that CRDs that come packaged as a gzipped tarball can be downloaded. It's determined by the URL path, rather than looking at response headers, because the content header may just be application/octet-stream (and is, for GitHub release attachments).

This is to support getting the CRDs for Flux conveniently, since they come attached to releases.
