### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build_sdk.yaml
+++ b/.github/workflows/build_sdk.yaml
@@ -29,7 +29,7 @@ jobs:
         run: poetry install
 
       - id: find_new_tags
-        run: echo "::set-output name=sdk_versions::[\"$(poetry run python ./bin/get-sdk-version.py ${{ github.event.inputs.sdk }} ${{ github.event.inputs.version }})\"]"
+        run: echo "sdk_versions=[\"$(poetry run python ./bin/get-sdk-version.py ${{ github.event.inputs.sdk }} ${{ github.event.inputs.version }})\"]" >> "$GITHUB_OUTPUT"
 
     outputs:
       sdk_versions: ${{ steps.find_new_tags.outputs.sdk_versions }}

--- a/.github/workflows/build_sdks.yaml
+++ b/.github/workflows/build_sdks.yaml
@@ -29,7 +29,7 @@ jobs:
         run: poetry install
 
       - id: find_new_tags
-        run: echo "::set-output name=sdk_versions::$(poetry run python ./bin/find-new-tags.py ${{ github.event.inputs.since_hours }})"
+        run: echo "sdk_versions=$(poetry run python ./bin/find-new-tags.py ${{ github.event.inputs.since_hours }})" >> "$GITHUB_OUTPUT"
 
     outputs:
       sdk_versions: ${{ steps.find_new_tags.outputs.sdk_versions }}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter